### PR TITLE
Fix infinite loader (from 1.0.1)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["FGBG"]
+  "cSpell.words": ["FGBG", "resizer"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
-# 1.0.1
+# 1.0.2
+
+- update `flex_color_scheme`, `google_fonts`, `isolate_handler`, `auto_route`
+- not use `AssetPathEntity.getAssetCount` (from `photo_manager`, deprecated)
+
+Additional changes:
+
+- rename `make route` to `make build`
+- compiles with Flutter 3.7
+
+# ~1.0.1~
+
+⚠️ When compiling for Android in release mode using flutter 3.3 or 3.7 has an infinite loop `Dart Error: Dart_LookupLibrary: library 'package:open_squeezer/views/home.dart' not found.`. Fixed in 1.0.2
 
 Added:
 

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,3 @@
-route:
+.PHONY: build
+build:
 	flutter packages pub run build_runner build

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Open-source, privacy respecting photo gallery cleaner for iOS and Android.
 
 ## Getting Started
 
-This is a Flutter application (currently this app is using Flutter 3.3.9).
+This is a Flutter application.
 
 A few resources to get you started if this is your first Flutter project:
 

--- a/lib/controllers/home_controller.dart
+++ b/lib/controllers/home_controller.dart
@@ -101,8 +101,6 @@ class HomeController {
     );
     final assetCounts = await _getAssetCounts(paths);
 
-    ;
-
     for (final path in paths) {
       var assetCount = assetCounts[path.id] ?? 1;
       var totalPages = (assetCount / kPhotoPageSize).ceil();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:google_fonts/google_fonts.dart';
 
-import 'router.gr.dart';
+import 'router.dart';
 import 'config/constants.dart';
 
 void main() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,9 +32,7 @@ class MyApp extends StatelessWidget {
       title: 'Open Squeezer',
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      routerDelegate: _appRouter.delegate(
-        initialDeepLink: "/",
-      ),
+      routerDelegate: _appRouter.delegate(),
       routeInformationParser: _appRouter.defaultRouteParser(),
       theme: lightTheme,
       darkTheme: darkTheme,

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -3,11 +3,16 @@ import 'package:auto_route/auto_route.dart';
 import 'views/clear_done.dart';
 import 'views/home.dart';
 
-@MaterialAutoRouter(
-  replaceInRouteName: 'Page,Route',
-  routes: <AutoRoute>[
-    AutoRoute(page: HomePage, initial: true),
-    AutoRoute(page: ClearDonePage),
-  ],
-)
-class $AppRouter {}
+import 'router.gr.dart';
+
+@AutoRouterConfig()
+class AppRouter extends $AppRouter {
+  @override
+  RouteType get defaultRouteType => RouteType.material();
+
+  @override
+  List<AutoRoute> get routes => [
+        AutoRoute(page: HomePage.page, initial: true),
+        AutoRoute(page: ClearDonePage.page),
+      ];
+}

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,8 +1,5 @@
 import 'package:auto_route/auto_route.dart';
 
-import 'views/clear_done.dart';
-import 'views/home.dart';
-
 import 'router.gr.dart';
 
 @AutoRouterConfig()

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -12,7 +12,7 @@ class AppRouter extends $AppRouter {
 
   @override
   List<AutoRoute> get routes => [
-        AutoRoute(page: HomePage.page, initial: true),
-        AutoRoute(page: ClearDonePage.page),
+        AutoRoute(page: HomeRoute.page, initial: true),
+        AutoRoute(page: ClearDoneRoute.page),
       ];
 }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -5,7 +5,7 @@ import 'router.gr.dart';
 @AutoRouterConfig()
 class AppRouter extends $AppRouter {
   @override
-  RouteType get defaultRouteType => RouteType.material();
+  RouteType get defaultRouteType => const RouteType.material();
 
   @override
   List<AutoRoute> get routes => [

--- a/lib/router.gr.dart
+++ b/lib/router.gr.dart
@@ -1,56 +1,61 @@
-// **************************************************************************
-// AutoRouteGenerator
-// **************************************************************************
-
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
-// AutoRouteGenerator
+// AutoRouterGenerator
 // **************************************************************************
-//
+
 // ignore_for_file: type=lint
+// coverage:ignore-file
 
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:auto_route/auto_route.dart' as _i3;
-import 'package:flutter/material.dart' as _i4;
+import 'package:open_squeezer/views/clear_done.dart' as _i2;
+import 'package:open_squeezer/views/home.dart' as _i1;
 
-import 'views/clear_done.dart' as _i2;
-import 'views/home.dart' as _i1;
-
-class AppRouter extends _i3.RootStackRouter {
-  AppRouter([_i4.GlobalKey<_i4.NavigatorState>? navigatorKey])
-      : super(navigatorKey);
+abstract class $AppRouter extends _i3.RootStackRouter {
+  $AppRouter({super.navigatorKey});
 
   @override
   final Map<String, _i3.PageFactory> pagesMap = {
     HomeRoute.name: (routeData) {
-      return _i3.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i1.HomePage());
+      return _i3.AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const _i1.HomePage(),
+      );
     },
     ClearDoneRoute.name: (routeData) {
-      return _i3.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i2.ClearDonePage());
-    }
+      return _i3.AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const _i2.ClearDonePage(),
+      );
+    },
   };
-
-  @override
-  List<_i3.RouteConfig> get routes => [
-        _i3.RouteConfig(HomeRoute.name, path: '/'),
-        _i3.RouteConfig(ClearDoneRoute.name, path: '/clear-done-page')
-      ];
 }
 
 /// generated route for
 /// [_i1.HomePage]
 class HomeRoute extends _i3.PageRouteInfo<void> {
-  const HomeRoute() : super(HomeRoute.name, path: '/');
+  const HomeRoute({List<_i3.PageRouteInfo>? children})
+      : super(
+          HomeRoute.name,
+          initialChildren: children,
+        );
 
   static const String name = 'HomeRoute';
+
+  static const _i3.PageInfo<void> page = _i3.PageInfo<void>(name);
 }
 
 /// generated route for
 /// [_i2.ClearDonePage]
 class ClearDoneRoute extends _i3.PageRouteInfo<void> {
-  const ClearDoneRoute() : super(ClearDoneRoute.name, path: '/clear-done-page');
+  const ClearDoneRoute({List<_i3.PageRouteInfo>? children})
+      : super(
+          ClearDoneRoute.name,
+          initialChildren: children,
+        );
 
   static const String name = 'ClearDoneRoute';
+
+  static const _i3.PageInfo<void> page = _i3.PageInfo<void>(name);
 }

--- a/lib/services/laplacian_analyzer.dart
+++ b/lib/services/laplacian_analyzer.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:ui' as ui;
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:image_edge_detection/functions.dart';

--- a/lib/services/laplacian_isolate.dart
+++ b/lib/services/laplacian_isolate.dart
@@ -8,7 +8,7 @@ import '../views/home.dart';
 
 /// Calculate laplacian on 2 isolates
 class LaplacianIsolate {
-  final _isolates = IsolateHandler();
+  late IsolateHandler _isolates;
   StreamController? _stream;
 
   late String name;
@@ -17,6 +17,8 @@ class LaplacianIsolate {
   LaplacianIsolate() {
     int nameId = Random().nextInt(100000);
     name = "squeezer_$nameId";
+
+    _isolates = IsolateHandler();
 
     _spawnIsolate();
   }

--- a/lib/services/laplacian_isolate.dart
+++ b/lib/services/laplacian_isolate.dart
@@ -26,16 +26,21 @@ class LaplacianIsolate {
   /// Message should be of type
   /// `List<LaplacianHomeIsolateMsg.toJson()>`.
   Future<void> _spawnIsolate() async {
-    _isolates.spawn<dynamic>(
-      LaplacianHomeIsolate.isolateHandler,
-      name: name,
-      onReceive: (msg) {
-        _stream?.add(msg);
-      },
-      onInitialized: () {
-        _isInit = true;
-      },
-    );
+    print("spawn isolate");
+    try {
+      _isolates.spawn<dynamic>(
+        LaplacianHomeIsolate.isolateHandler,
+        name: name,
+        onReceive: (msg) {
+          _stream?.add(msg);
+        },
+        onInitialized: () {
+          _isInit = true;
+        },
+      );
+    } catch (e) {
+      print("Error spawning isolate: $e");
+    }
   }
 
   Future<void> waitInit() async {
@@ -56,35 +61,40 @@ class LaplacianIsolate {
     await completer.future;
   }
 
-  /// Calculate blur for all assets with laplacian analyzer.
-  /// Will send all the payload to an isolate
-  Future<List<LaplacianHomeIsolateResp>> allAssetsBlur(
+  Future<List> allAssetsBlur(
     Iterable<String> assetsIds,
   ) async {
-    List<String> messages = List.empty(growable: true);
-
-    for (final assetId in assetsIds) {
-      messages.add(
-        LaplacianHomeIsolateMsg(id: assetId).toJson(),
-      );
-    }
-
-    List<String> allItems = await _sendPayload(messages);
-
-    List<LaplacianHomeIsolateResp> responses = List.empty(growable: true);
-
-    for (var respJson in allItems) {
-      var r = LaplacianHomeIsolateResp.fromJson(respJson);
-
-      if (r == null) {
-        continue;
-      }
-
-      responses.add(r);
-    }
-
-    return responses;
+    return [];
   }
+  // /// Calculate blur for all assets with laplacian analyzer.
+  // /// Will send all the payload to an isolate
+  // Future<List<LaplacianHomeIsolateResp>> allAssetsBlur(
+  //   Iterable<String> assetsIds,
+  // ) async {
+  //   List<String> messages = List.empty(growable: true);
+
+  //   for (final assetId in assetsIds) {
+  //     messages.add(
+  //       LaplacianHomeIsolateMsg(id: assetId).toJson(),
+  //     );
+  //   }
+
+  //   List<String> allItems = await _sendPayload(messages);
+
+  //   List<LaplacianHomeIsolateResp> responses = List.empty(growable: true);
+
+  //   for (var respJson in allItems) {
+  //     var r = LaplacianHomeIsolateResp.fromJson(respJson);
+
+  //     if (r == null) {
+  //       continue;
+  //     }
+
+  //     responses.add(r);
+  //   }
+
+  //   return responses;
+  // }
 
   Future<List<String>> _sendPayload(List<String> message) async {
     if (!_isInit) {

--- a/lib/services/laplacian_isolate.dart
+++ b/lib/services/laplacian_isolate.dart
@@ -8,7 +8,7 @@ import '../views/home.dart';
 
 /// Calculate laplacian on 2 isolates
 class LaplacianIsolate {
-  late IsolateHandler _isolates;
+  final _isolates = IsolateHandler();
   StreamController? _stream;
 
   late String name;
@@ -17,8 +17,6 @@ class LaplacianIsolate {
   LaplacianIsolate() {
     int nameId = Random().nextInt(100000);
     name = "squeezer_$nameId";
-
-    _isolates = IsolateHandler();
 
     _spawnIsolate();
   }

--- a/lib/services/laplacian_isolate.dart
+++ b/lib/services/laplacian_isolate.dart
@@ -26,7 +26,6 @@ class LaplacianIsolate {
   /// Message should be of type
   /// `List<LaplacianHomeIsolateMsg.toJson()>`.
   Future<void> _spawnIsolate() async {
-    print("spawn isolate");
     try {
       _isolates.spawn<dynamic>(
         LaplacianHomeIsolate.isolateHandler,
@@ -39,7 +38,7 @@ class LaplacianIsolate {
         },
       );
     } catch (e) {
-      print("Error spawning isolate: $e");
+      debugPrint("Error spawning isolate: $e");
     }
   }
 
@@ -61,40 +60,35 @@ class LaplacianIsolate {
     await completer.future;
   }
 
-  Future<List> allAssetsBlur(
+  /// Calculate blur for all assets with laplacian analyzer.
+  /// Will send all the payload to an isolate
+  Future<List<LaplacianHomeIsolateResp>> allAssetsBlur(
     Iterable<String> assetsIds,
   ) async {
-    return [];
+    List<String> messages = List.empty(growable: true);
+
+    for (final assetId in assetsIds) {
+      messages.add(
+        LaplacianHomeIsolateMsg(id: assetId).toJson(),
+      );
+    }
+
+    List<String> allItems = await _sendPayload(messages);
+
+    List<LaplacianHomeIsolateResp> responses = List.empty(growable: true);
+
+    for (var respJson in allItems) {
+      var r = LaplacianHomeIsolateResp.fromJson(respJson);
+
+      if (r == null) {
+        continue;
+      }
+
+      responses.add(r);
+    }
+
+    return responses;
   }
-  // /// Calculate blur for all assets with laplacian analyzer.
-  // /// Will send all the payload to an isolate
-  // Future<List<LaplacianHomeIsolateResp>> allAssetsBlur(
-  //   Iterable<String> assetsIds,
-  // ) async {
-  //   List<String> messages = List.empty(growable: true);
-
-  //   for (final assetId in assetsIds) {
-  //     messages.add(
-  //       LaplacianHomeIsolateMsg(id: assetId).toJson(),
-  //     );
-  //   }
-
-  //   List<String> allItems = await _sendPayload(messages);
-
-  //   List<LaplacianHomeIsolateResp> responses = List.empty(growable: true);
-
-  //   for (var respJson in allItems) {
-  //     var r = LaplacianHomeIsolateResp.fromJson(respJson);
-
-  //     if (r == null) {
-  //       continue;
-  //     }
-
-  //     responses.add(r);
-  //   }
-
-  //   return responses;
-  // }
 
   Future<List<String>> _sendPayload(List<String> message) async {
     if (!_isInit) {

--- a/lib/views/clear_done.dart
+++ b/lib/views/clear_done.dart
@@ -6,6 +6,7 @@ import 'package:auto_route/auto_route.dart';
 import '../config/constants.dart';
 import '../router.gr.dart';
 
+@RoutePage()
 class ClearDonePage extends StatelessWidget {
   const ClearDonePage({Key? key}) : super(key: key);
 

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -7,12 +7,14 @@ import 'package:flutter_fgbg/flutter_fgbg.dart';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:isolate_handler/isolate_handler.dart' as ih;
-import 'package:open_squeezer/widgets/button_about.dart';
 import 'package:photo_manager/photo_manager.dart' as pm;
 
 import '../services/laplacian_analyzer.dart';
+
 import '../widgets/album.dart';
 import '../widgets/no_permissions.dart';
+import '../widgets/button_about.dart';
+
 import '../config/constants.dart';
 import '../controllers/home_controller.dart';
 
@@ -108,7 +110,7 @@ class _HomePageState extends State<HomePage> {
     return Scaffold(
       appBar: AppBar(
         title: Text(loc.appName),
-        actions: [AboutButton()],
+        actions: const [AboutButton()],
       ),
       body: Padding(
         padding: const EdgeInsets.all(kScaffoldPadding),

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -10,15 +10,17 @@ import 'package:isolate_handler/isolate_handler.dart' as ih;
 import 'package:open_squeezer/widgets/button_about.dart';
 import 'package:photo_manager/photo_manager.dart' as pm;
 
-import '../router.gr.dart';
 import '../services/laplacian_analyzer.dart';
 import '../widgets/album.dart';
 import '../widgets/no_permissions.dart';
 import '../config/constants.dart';
 import '../controllers/home_controller.dart';
 
+import '../router.gr.dart';
+
 part 'home_laplacian_isolate.dart';
 
+@RoutePage()
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
 

--- a/lib/views/home_laplacian_isolate.dart
+++ b/lib/views/home_laplacian_isolate.dart
@@ -125,6 +125,7 @@ class LaplacianHomeIsolate {
 
   /// Handle blur processing.
   /// Should have a list of messages containing List<LaplacianHomeIsolateMsg>
+  @pragma('vm:entry-point')
   static void isolateHandler(dynamic context) async {
     final messenger = ih.HandledIsolate.initialize(context);
 
@@ -135,10 +136,8 @@ class LaplacianHomeIsolate {
     messenger.listen((msg) async {
       if (msg is! List<String>) {
         debugPrint(
-          """
-            Invalid message type '${msg.runtimeType}' 
-            in LaplacianHomeIsolate.analyze, skipping
-          """,
+          "Invalid message type '${msg.runtimeType}' "
+          "in LaplacianHomeIsolate.analyze, skipping",
         );
         return;
       }

--- a/lib/views/home_laplacian_isolate.dart
+++ b/lib/views/home_laplacian_isolate.dart
@@ -90,7 +90,7 @@ class LaplacianHomeIsolate {
         variance: variance ?? 0,
       ).toJson();
     } catch (e) {
-      debugPrint("Error getting variance for ");
+      debugPrint("Error getting variance for ${message.id}: $e");
     }
 
     return "";

--- a/lib/views/home_laplacian_isolate.dart
+++ b/lib/views/home_laplacian_isolate.dart
@@ -69,7 +69,6 @@ class LaplacianHomeIsolateResp {
   }
 }
 
-///
 class LaplacianHomeIsolate {
   static Future<String> getVariance(LaplacianHomeIsolateMsg message) async {
     try {

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import package_info_plus
-import path_provider_macos
+import path_provider_foundation
 import photo_manager
 import url_launcher_macos
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,226 +5,250 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "8880b4cfe7b5b17d57c052a5a3a8cc1d4f546261c7cc8fbd717bd53f48db0568"
+      url: "https://pub.dev"
     source: hosted
-    version: "41.0.0"
+    version: "59.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: a89627f49b0e70e068130a36571409726b04dab12da7e5625941d2c8ec278b96
+      url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "5.11.1"
   archive:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.7"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "4cab82a83ffef80b262ddedf47a0a8e56ee6fbf7fe21e6e768b02792034dd440"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   auto_route:
     dependency: "direct main"
     description:
       name: auto_route
-      url: "https://pub.dartlang.org"
+      sha256: "9a2579b115cc42eb3c787c86deae2ffc4128dc6f1af976580e7f8e4bb7f803c6"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.2.1"
+    version: "6.4.0"
   auto_route_generator:
     dependency: "direct dev"
     description:
       name: auto_route_generator
-      url: "https://pub.dartlang.org"
+      sha256: e8056df4ff40700ce80b1fc7889cf62bfbb5250225f5fb2ea55d1f1271010a60
+      url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "6.2.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   build:
     dependency: transitive
     description:
       name: build
-      url: "https://pub.dartlang.org"
+      sha256: "3fbda25365741f8251b39f3917fb3c8e286a96fd068a5a242e11c2012d495777"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      url: "https://pub.dartlang.org"
+      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      url: "https://pub.dartlang.org"
+      sha256: "757153e5d9cd88253cb13f28c2fb55a537dc31fefd98137549895b5beb7c6169"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      url: "https://pub.dartlang.org"
+      sha256: db49b8609ef8c81cca2b310618c3017c00f03a92af44c04d310b907b2d692d95
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.9"
+    version: "2.2.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      url: "https://pub.dartlang.org"
+      sha256: b0a8a7b8a76c493e85f1b84bffa0588859a06197863dba8c9036b15581fd9727
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.3"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      url: "https://pub.dartlang.org"
+      sha256: "14febe0f5bac5ae474117a36099b4de6f1dbc52df6c5e55534b3da9591bf4292"
+      url: "https://pub.dev"
     source: hosted
-    version: "7.2.3"
+    version: "7.2.7"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      url: "https://pub.dartlang.org"
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      url: "https://pub.dartlang.org"
+      sha256: "31b7c748fd4b9adf8d25d72a4c4a59ef119f12876cf414f94f8af5131d5fa2b0"
+      url: "https://pub.dev"
     source: hosted
-    version: "8.4.0"
+    version: "8.4.4"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      url: "https://pub.dartlang.org"
+      sha256: "0d43dd1288fd145de1ecc9a3948ad4a6d5a82f0a14c4fdd0892260787d975cbe"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.4.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      url: "https://pub.dartlang.org"
+      sha256: "6d691edde054969f0e0f26abb1b30834b5138b963793e56f69d3a9a4435e6352"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.3.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   flex_color_scheme:
     dependency: "direct main"
     description:
       name: flex_color_scheme
-      url: "https://pub.dartlang.org"
+      sha256: "92e55a32cb0cbcde333c2169612785ed236a7b136534de983b3037b39d06e96c"
+      url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "7.0.5"
+  flex_seed_scheme:
+    dependency: transitive
+    description:
+      name: flex_seed_scheme
+      sha256: b3678d82403c13dec2ee2721e078b26f14577712411b6aa981b0f4269df3fabb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -234,21 +258,24 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_fgbg
-      url: "https://pub.dartlang.org"
+      sha256: d37511eef6afb7e2e3f2278ec6498bb12c650ed517c81bcd09452d910e8b9174
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   flutter_isolate:
     dependency: transitive
     description:
       name: flutter_isolate
-      url: "https://pub.dartlang.org"
+      sha256: "994ddec596da4ca12ca52154fd59404077584643eb7e3f1008a55fda9fe0b76b"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.4"
   flutter_lints:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_localizations:
@@ -270,71 +297,72 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "3.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   google_fonts:
     dependency: "direct main"
     description:
       name: google_fonts
-      url: "https://pub.dartlang.org"
+      sha256: "6b6f10f0ce3c42f6552d1c70d2c28d764cf22bb487f50f66cca31dcd5194f4d6"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "4.0.4"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      url: "https://pub.dartlang.org"
+      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.15.0"
+    version: "2.2.0"
   http:
     dependency: transitive
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.6"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   image:
     dependency: "direct main"
     description:
       name: image
-      url: "https://pub.dartlang.org"
+      sha256: "8e9d133755c3e84c73288363e6343157c383a0c6c56fc51afcc5d4d7180306d6"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.3.0"
   image_edge_detection:
     dependency: "direct main"
     description:
       path: "."
       ref: HEAD
-      resolved-ref: f3e15841e93e3ff0b63014f7730b6be32dd8caae
+      resolved-ref: "9aa085b6a44f6dd682085489588be257260c7e8b"
       url: "https://github.com/nWacky/edge_detection"
     source: git
     version: "0.0.3"
@@ -342,226 +370,258 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      url: "https://pub.dartlang.org"
+      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
+      url: "https://pub.dev"
     source: hosted
     version: "0.17.0"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   isolate_handler:
     dependency: "direct main"
     description:
       name: isolate_handler
-      url: "https://pub.dartlang.org"
+      sha256: "7d90f2694551b4b18cbb3b635ad650a73b522854e9232f4b1227bb64914f1fde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      url: "https://pub.dev"
     source: hosted
-    version: "4.6.0"
+    version: "4.8.0"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   package_info_plus:
     dependency: "direct main"
     description:
       name: package_info_plus
-      url: "https://pub.dartlang.org"
+      sha256: "10259b111176fba5c505b102e3a5b022b51dd97e30522e906d6922c745584745"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   path_provider:
     dependency: "direct main"
     description:
       name: path_provider
-      url: "https://pub.dartlang.org"
+      sha256: c7edf82217d4b2952b2129a61d3ad60f1075b9299e629e149a8d2e39c2e6aad4
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.14"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      url: "https://pub.dartlang.org"
+      sha256: "2cec049d282c7f13c594b4a73976b0b4f2d7a1838a6dd5aaf7bd9719196bee86"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.16"
-  path_provider_ios:
+    version: "2.0.27"
+  path_provider_foundation:
     dependency: transitive
     description:
-      name: path_provider_ios
-      url: "https://pub.dartlang.org"
+      name: path_provider_foundation
+      sha256: ad4c4d011830462633f03eb34445a45345673dfd4faf1ab0b4735fbd93b19183
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.10"
+    version: "2.2.2"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      url: "https://pub.dartlang.org"
+      sha256: "2ae08f2216225427e64ad224a24354221c2c7907e448e6e0e8b57b1eb9f10ad1"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.7"
-  path_provider_macos:
-    dependency: transitive
-    description:
-      name: path_provider_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.6"
+    version: "2.1.10"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "57585299a729335f1298b43245842678cb9f43a6310351b18fb577d6e33165ec"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.6"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      url: "https://pub.dartlang.org"
+      sha256: d3f80b32e83ec208ac95253e0cd4d298e104fbc63cb29c5c69edaed43b0c69d6
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.6"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      url: "https://pub.dartlang.org"
+      sha256: "49392a45ced973e8d94a85fdb21293fbb40ba805fc49f2965101ae748a3683b4"
+      url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "5.1.0"
   photo_manager:
     dependency: "direct main"
     description:
       name: photo_manager
-      url: "https://pub.dartlang.org"
+      sha256: bdc4ab1fa9fb064d8ccfea6ab44119f55b220293d7ce2e19eb5a5f998db86c88
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.6.0"
   platform:
     dependency: transitive
     description:
       name: platform
-      url: "https://pub.dartlang.org"
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.7.3"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   process:
     dependency: transitive
     description:
       name: process
-      url: "https://pub.dartlang.org"
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dartlang.org"
+      sha256: ec85d7d55339d85f44ec2b682a82fea340071e8978257e5a43e69f79e98ef50c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.2"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -571,198 +631,210 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      url: "https://pub.dartlang.org"
+      sha256: c2bea18c95cfa0276a366270afaa2850b09b4a76db95d546f3d003dcc7011298
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.7"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      url: "https://pub.dartlang.org"
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.16"
   timing:
     dependency: transitive
     description:
       name: timing
-      url: "https://pub.dartlang.org"
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
-  universal_html:
-    dependency: transitive
-    description:
-      name: universal_html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.8"
-  universal_io:
-    dependency: transitive
-    description:
-      name: universal_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.4"
   url_launcher:
     dependency: "direct main"
     description:
       name: url_launcher
-      url: "https://pub.dartlang.org"
+      sha256: "75f2846facd11168d007529d6cd8fcb2b750186bea046af9711f10b907e1587e"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.10"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      url: "https://pub.dartlang.org"
+      sha256: "22f8db4a72be26e9e3a4aa3f194b1f7afbc76d20ec141f84be1d787db2155cbd"
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.31"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      url: "https://pub.dartlang.org"
+      sha256: "9af7ea73259886b92199f9e42c116072f05ff9bea2dcb339ab935dfc957392c2"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      url: "https://pub.dartlang.org"
+      sha256: "207f4ddda99b95b4d4868320a352d374b0b7e05eefad95a4a26f57da413443f5"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.5"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      url: "https://pub.dartlang.org"
+      sha256: "91ee3e75ea9dadf38036200c5d3743518f4a5eb77a8d13fda1ee5764373f185e"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.5"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "6c9ca697a5ae218ce56cece69d46128169a58aa8653c1b01d26fcd4aad8c4370"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      url: "https://pub.dartlang.org"
+      sha256: "81fe91b6c4f84f222d186a9d23c73157dc4c8e1c71489c4d08be1ad3b228f1aa"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.16"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      url: "https://pub.dartlang.org"
+      sha256: "254708f17f7c20a9c8c471f67d86d76d4a3f9c1591aad1e15292008aceb82771"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      url: "https://pub.dartlang.org"
+      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.0"
   win32:
     dependency: transitive
     description:
       name: win32
-      url: "https://pub.dartlang.org"
+      sha256: dd8f9344bc305ae2923e3d11a2a911d9a4e2c7dd6fe0ed10626d63211a69676e
+      url: "https://pub.dev"
     source: hosted
-    version: "2.7.0"
+    version: "4.1.3"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      url: "https://pub.dartlang.org"
+      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.0+1"
+    version: "1.0.0"
   xml:
     dependency: transitive
     description:
       name: xml
-      url: "https://pub.dartlang.org"
+      sha256: "979ee37d622dec6365e2efa4d906c37470995871fe9ae080d967e192d88286b5"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "6.2.2"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=2.19.0 <3.0.0"
+  flutter: ">=3.7.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,13 +37,13 @@ dependencies:
   cupertino_icons: ^1.0.2
   path_provider: ^2.0.11
   image: ^3.2.0
-  flex_color_scheme: ^5.1.0
+  flex_color_scheme: ^7.0.5
   intl: ^0.17.0
-  google_fonts: ^3.0.1
+  google_fonts: ^4.0.4
   photo_manager: ^2.1.4
-  isolate_handler: ^1.0.1
+  isolate_handler: ^1.0.2
   flutter_fgbg: ^0.2.0
-  auto_route: ^4.2.1
+  auto_route: ^6.4.0
   image_edge_detection:
     git: "https://github.com/nWacky/edge_detection"
   package_info_plus: ^3.1.2
@@ -59,7 +59,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
-  auto_route_generator: ^4.0.0
+  auto_route_generator: ^6.2.0
   build_runner:
 
 # For information on the generic Dart part of this file, see the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,7 +59,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
-  auto_route_generator: ^6.4.0
+  auto_route_generator: ^6.2.0
   build_runner:
 
 # For information on the generic Dart part of this file, see the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,7 +59,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
-  auto_route_generator: ^6.2.0
+  auto_route_generator: ^6.4.0
   build_runner:
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
In 1.0.1 there was a bug when compiling with flutter 3.3 and 3.7:

```
Dart Error: Dart_LookupLibrary: library 'package:open_squeezer/views/home.dart' not found
```

Which caused the loader to show infinitely without any work being done. 

In this PR I fixed the issue (wrapped `isolateHandler` in `@pragma('vm:entry-point')`) and updated dependencies