### PR TITLE
Update `targetSdkVersion` to 34 (Android 14)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -53,7 +53,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
> When you upload an APK, it must meet Google Play's target API level requirements.
>
> Starting August 31 2024:
>
> - New apps and app updates must target Android 14 (API level 34) or higher to be submitted to Google Play;
> - Existing apps must target Android 13 (API level 33) or higher to remain available to new users on devices running Android OS higher than your app's target API level.
>
> _(from [Google Play's target API level requirement - developer.android.com](https://developer.android.com/google/play/requirements/target-sdk))_

Update `targetSdkVersion` to 34 (Android 14)

Tested on Android 14, seems to work.

Launched with flutter `3.13.9`